### PR TITLE
add an API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,26 @@ Nodes cannot be placed directly in front of handholds, and falling nodes landing
 
 Thanks to paramat, Zeno, LazyJ, Billre and NathanS21 for testing and suggestions.
 
+API
+---
+
+This mod offers an API that other mods can call to add new types of handhold nodes:
+
+```
+handholds.register_handholds_node(base_node_name, handhold_node_name, handhold_def_override)
+```
+
+base_node_name is the node that's having a handholds node created for it.
+
+handhold_node_name is the name of the handhold node to be registered.
+
+handhold_def_override is an optional table of properties to override on the handhold def before it is registered.
+
+for example:
+
+```
+handholds.register_handholds_node("default:dirt", "dirtyfun:dirt_handholds", {description="Climbable Dirt"})
+```
 
 Licenses and Attribution 
 -----------------------


### PR DESCRIPTION
I was looking into adding handholds support for the flowstone columns I've put in my "dfcaverns" mod and it seemed like a good idea to add an API to handholds to allow any mod to hook up new climbable node types. Here's my attempt at that. How's it look? I think it should be able to make a handhold node type out of most any generic node you put into it.